### PR TITLE
feat: Implements infinity scroll api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 !**/src/test/**/build/
 /node_modules
 **/generated
+**/application-local.yml
 
 ### STS ###
 .apt_generated

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ build/
 !**/src/test/**/build/
 /node_modules
 **/generated
-**/application-local.yml
+resource/application-local.yml
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'org.springframework.boot' version '2.6.5'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
@@ -9,6 +15,12 @@ group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
 repositories {
     mavenCentral()
 }
@@ -16,44 +28,46 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
     implementation 'mysql:mysql-connector-java'
-    implementation 'com.querydsl:querydsl-jpa'
+
+    //querydsl 추가
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    //테스트에서 lombok 사용
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     // dummy data insert용
     implementation "org.springframework.cloud:spring-cloud-starter-openfeign:3.1.0"
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
-def querydslSrcDir = 'src/main/generated'
+def querydslDir = 'src/main/generated'
 
 querydsl {
-    library = "com.querydsl:querydsl-apt"
     jpa = true
-    querydslSourcesDir = querydslSrcDir
-}
-
-compileQuerydsl{
-    options.annotationProcessorPath = configurations.querydsl
-}
-
-configurations {
-    querydsl.extendsFrom compileClasspath
+    querydslSourcesDir = querydslDir
 }
 
 sourceSets {
-    main {
-        java {
-            srcDirs = ['src/main/java', querydslSrcDir]
-        }
-    }
+    main.java.srcDir querydslDir
 }
 
 configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
     querydsl.extendsFrom compileClasspath
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/src/main/java/com/example/paging/controller/PostController.java
+++ b/src/main/java/com/example/paging/controller/PostController.java
@@ -2,6 +2,7 @@ package com.example.paging.controller;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -33,5 +34,12 @@ public class PostController {
         log.info("{}", pageable);
         log.info("요청한 페이지 : {}, 크기 : {}", pageable.getOffset(), pageable.getPageSize());
         return postService.getPosts(pageable);
+    }
+
+    @GetMapping("/api/v2/posts")
+    public Slice<PostDto> getPostsV2(@PageableDefault(sort = "createDate", direction = Direction.DESC) Pageable pageable) {
+        log.info("{}", pageable);
+        log.info("요청한 페이지 : {}, 크기 : {}", pageable.getOffset(), pageable.getPageSize());
+        return postService.getPostsV2(pageable);
     }
 }

--- a/src/main/java/com/example/paging/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/example/paging/repository/PostRepositoryCustom.java
@@ -2,9 +2,12 @@ package com.example.paging.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import com.example.paging.dto.PostDto;
 
 public interface PostRepositoryCustom {
     Page<PostDto> search(Pageable pageable);
+
+    Slice<PostDto> searchV2(Pageable pageable);
 }

--- a/src/main/java/com/example/paging/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/example/paging/repository/PostRepositoryImpl.java
@@ -2,13 +2,17 @@ package com.example.paging.repository;
 
 import static com.example.paging.entity.QPost.post;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import com.example.paging.dto.PostDto;
 import com.example.paging.dto.QPostDto;
+import com.example.paging.util.SliceHelper;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.PathBuilder;
@@ -43,5 +47,23 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
         return PageableExecutionUtils.getPage(query.fetch(), pageable, query::fetchCount);
 
+    }
+
+    @Override
+    public Slice<PostDto> searchV2(final Pageable pageable) {
+        final List<PostDto> contents = queryFactory.select(new QPostDto(
+                                                        post.id,
+                                                        post.thumbnail,
+                                                        post.title,
+                                                        post.contents,
+                                                        post.author,
+                                                        post.createDate,
+                                                        post.updateDate
+                                                )).from(post)
+                                                .offset(pageable.getOffset())
+                                                .limit(pageable.getPageSize() + 1)
+                                                .fetch();
+
+        return SliceHelper.getSlice(contents, pageable);
     }
 }

--- a/src/main/java/com/example/paging/service/PostService.java
+++ b/src/main/java/com/example/paging/service/PostService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,5 +23,9 @@ public class PostService {
 
     public Page<PostDto> getPosts(Pageable pageable) {
         return postRepository.search(pageable);
+    }
+
+    public Slice<PostDto> getPostsV2(Pageable pageable) {
+        return postRepository.searchV2(pageable);
     }
 }

--- a/src/main/java/com/example/paging/util/SliceHelper.java
+++ b/src/main/java/com/example/paging/util/SliceHelper.java
@@ -14,8 +14,6 @@ public class SliceHelper {
             hasNext = true;
         }
 
-        System.out.println("hasNext: "+ hasNext);
-
         return new SliceImpl<>(content, pageable, hasNext);
     }
 }

--- a/src/main/java/com/example/paging/util/SliceHelper.java
+++ b/src/main/java/com/example/paging/util/SliceHelper.java
@@ -1,0 +1,21 @@
+package com.example.paging.util;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+public class SliceHelper {
+    public static <T> Slice<T> getSlice(List<T> content, Pageable pageable) {
+        boolean hasNext = false;
+        if(content.size() > pageable.getPageSize()){
+            content.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        System.out.println("hasNext: "+ hasNext);
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,3 +1,0 @@
-fake:
-  api:
-    appId: 623f211a5599137c08cef1e3

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,3 @@
+fake:
+  api:
+    appId: 623f211a5599137c08cef1e3

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,6 @@ spring:
       hibernate:
         default_batch_fetch_size: 1000
 
-
 fake:
   api:
     appId: {여기에 https://dummyapi.io 앱 아이디를 입력하세요}


### PR DESCRIPTION
- 기존과 같은 방식으로 pageNum을 보내주면 됩니다.
  - ex) `http://localhost:8080/api/v2/posts?page=143`
- 기본으로 10개씩 Post를 제공합니다.
- 이번엔 전체 개수는 제공하지 않아요.
- 그래서 페이지 번호를 미리 계산할 수 없어요.
- 이건 무한 스크롤을 위해서 기존과 다르게 이 다음에도 제공할 수 있는지 확인하는 것을 `last` field로 확인하시면 됩니다.
- 즉, last = false 이면 계속 요청하시면 되고, last = true이면 마지막 페이지라는 의미입니다.
<img width="442" alt="image" src="https://user-images.githubusercontent.com/37108728/160272833-e03f8f9a-7ff3-4954-949c-faf8de340e91.png">
